### PR TITLE
[BT-880] auth helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To interact with `images` and `containers` directly, you can use [`nerdctl`](htt
 | **stats_interval** | string | no | 1s | Interval for collecting `TaskStats`. |
 | **allow_privileged** | bool | no | true | If set to `false`, driver will deny running privileged jobs. |
 | **auth** | block | no | N/A | Provide authentication for a private registry. See [Authentication](#authentication-private-registry) for more details. |
-| **auth_helper** | block | no | N/A | Lookup authentication information from external sources. See [Authentication Helper](example/agent-auth-helper.hcl) for more details. |
+| **auth_helper** | block | no | N/A | Lookup authentication information from external sources. See [Authentication Helper](example/agent-auth-helper.hcl) for more details. Order of precedence Job Auth, Config Auth, Config Auth Helper.  |
 
 **Task Config**
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ To interact with `images` and `containers` directly, you can use [`nerdctl`](htt
 | **stats_interval** | string | no | 1s | Interval for collecting `TaskStats`. |
 | **allow_privileged** | bool | no | true | If set to `false`, driver will deny running privileged jobs. |
 | **auth** | block | no | N/A | Provide authentication for a private registry. See [Authentication](#authentication-private-registry) for more details. |
+| **auth_helper** | block | no | N/A | Lookup authentication information from external sources. See [Authentication Helper](example/agent-auth-helper.hcl) for more details. |
 
 **Task Config**
 

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -60,6 +60,10 @@ const (
 	taskHandleVersion = 1
 )
 
+const (
+	authHelperPrefix = "docker-credential-"
+)
+
 var (
 	// pluginInfo describes the plugin
 	pluginInfo = &base.PluginInfoResponse{
@@ -87,6 +91,9 @@ var (
 		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"username": hclspec.NewAttr("username", "string", true),
 			"password": hclspec.NewAttr("password", "string", true),
+		})),
+		"auth_helper": hclspec.NewBlock("auth_helper", false, hclspec.NewObject(map[string]*hclspec.Spec{
+			"helper": hclspec.NewAttr("helper", "string", true),
 		})),
 	})
 
@@ -158,11 +165,12 @@ var (
 
 // Config contains configuration information for the plugin
 type Config struct {
-	Enabled           bool         `codec:"enabled"`
-	ContainerdRuntime string       `codec:"containerd_runtime"`
-	StatsInterval     string       `codec:"stats_interval"`
-	AllowPrivileged   bool         `codec:"allow_privileged"`
-	Auth              RegistryAuth `codec:"auth"`
+	Enabled           bool               `codec:"enabled"`
+	ContainerdRuntime string             `codec:"containerd_runtime"`
+	StatsInterval     string             `codec:"stats_interval"`
+	AllowPrivileged   bool               `codec:"allow_privileged"`
+	Auth              RegistryAuth       `codec:"auth"`
+	AuthHelper        RegistryAuthHelper `codec:"auth_helper"`
 }
 
 // Volume, bind, and tmpfs type mounts are supported.
@@ -178,6 +186,11 @@ type Mount struct {
 type RegistryAuth struct {
 	Username string `codec:"username"`
 	Password string `codec:"password"`
+}
+
+// RegistryAuthHelper info to pull image from registry when using helper binary.
+type RegistryAuthHelper struct {
+	Helper string `codec:"helper"`
 }
 
 // TaskConfig contains configuration information for a task that runs with
@@ -419,7 +432,11 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("task with ID %q already started", cfg.ID)
 	}
 
-	var driverConfig TaskConfig
+	var (
+		driverConfig TaskConfig
+		err          error
+	)
+
 	if err := cfg.DecodeDriverConfig(&driverConfig); err != nil {
 		return nil, nil, fmt.Errorf("failed to decode driver config: %v", err)
 	}
@@ -442,8 +459,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	containerName := cfg.Name + "-" + cfg.AllocID
 	containerConfig.ContainerName = containerName
 
-	var err error
-	containerConfig.Image, err = d.pullImage(driverConfig.Image, driverConfig.ImagePullTimeout, &driverConfig.Auth)
+	authFunc := d.resolveRegistryAuthentication(&driverConfig, driverConfig.Image)
+
+	containerConfig.Image, err = d.pullImage(driverConfig.Image, driverConfig.ImagePullTimeout, authFunc)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error in pulling image %s: %v", driverConfig.Image, err)
 	}

--- a/containerd/utils.go
+++ b/containerd/utils.go
@@ -126,7 +126,7 @@ func WithSwap(swap int64, swapiness uint64) oci.SpecOpts {
 func memoryInBytes(strmem string) (int64, error) {
 	l := len(strmem)
 	if l < 2 {
-		return 0, fmt.Errorf("Invalid memory string: %s", strmem)
+		return 0, fmt.Errorf("invalid memory swap string: %s", strmem)
 	}
 	ival, err := strconv.Atoi(strmem[0 : l-1])
 	if err != nil {
@@ -143,6 +143,6 @@ func memoryInBytes(strmem string) (int64, error) {
 	case 'g':
 		return int64(ival) * 1024 * 1024 * 1024, nil
 	default:
-		return 0, fmt.Errorf("Invalid memory string: %s", strmem)
+		return 0, fmt.Errorf("invalid memory swap string: %s", strmem)
 	}
 }

--- a/example/agent-auth-helper.hcl
+++ b/example/agent-auth-helper.hcl
@@ -1,0 +1,37 @@
+log_level = "INFO"
+data_dir = "/tmp/nomad"
+
+plugin "containerd-driver" {
+  config {
+    enabled = true
+    containerd_runtime = "io.containerd.runc.v1"
+    stats_interval = "5s"
+
+    auth_helper {
+      helper = "/usr/bin/docker-credential-gcr"
+    }
+  }
+}
+
+server {
+  enabled = true
+  bootstrap_expect = 1
+  default_scheduler_config {
+    scheduler_algorithm = "spread"
+    memory_oversubscription_enabled = true
+
+    preemption_config {
+      batch_scheduler_enabled   = true
+      system_scheduler_enabled  = true
+      service_scheduler_enabled = true
+    }
+  }
+}
+
+client {
+  enabled = true
+  host_volume "s1" {
+    path = "/tmp/host_volume/s1"
+    read_only = false
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/cgroups v1.0.1
 	github.com/containerd/containerd v1.5.8
 	github.com/containerd/typeurl v1.0.2
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200330121334-7f8b4b621b5d+incompatible
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
 	github.com/docker/go-units v0.4.0
@@ -15,6 +16,7 @@ require (
 	github.com/hashicorp/consul-template v0.25.2
 	github.com/hashicorp/go-envparse v0.0.0-20190703193109-150b3a2a4611 // indirect
 	github.com/hashicorp/go-hclog v0.14.1
+	github.com/hashicorp/go-msgpack v1.1.5
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/nomad v1.1.4
 	github.com/opencontainers/image-spec v1.0.2 // indirect


### PR DESCRIPTION
- Add `auth_helper` block to allow for dynamic image repository credentials.
- Order of precedence regarding auth: Job Auth Block, Config Auth Block, Config AuthHelper Block