### PR TITLE
Add GPU support in conjunction with nomad-nvidia-device plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ To interact with `images` and `containers` directly, you can use [`nerdctl`](htt
 | **containerd_runtime** | string | no | `io.containerd.runc.v2` | Runtime for containerd. |
 | **stats_interval** | string | no | 1s | Interval for collecting `TaskStats`. |
 | **allow_privileged** | bool | no | true | If set to `false`, driver will deny running privileged jobs. |
+| **allow_runtimes** | []string | no | `["runc", "runsc", "nvidia"]` | Runtimes that are allowed to be used. |
 | **auth** | block | no | N/A | Provide authentication for a private registry. See [Authentication](#authentication-private-registry) for more details. |
 | **auth_helper** | block | no | N/A | Lookup authentication information from external sources. See [Authentication Helper](example/agent-auth-helper.hcl) for more details. Order of precedence Job Auth, Config Auth, Config Auth Helper.  |
+| **nvidia_runtime** | string | no | `nvidia` | Runtime for nvidia. This is generally not required to specify since GPUs are part of OCI hooks using `runc` as the runtime. |
 
 ## Supported Runtimes
 
@@ -99,6 +101,7 @@ Valid options for `containerd_runtime` (**Driver Config**).
 - `io.containerd.runc.v1`: `runc` runtime that supports a single container.
 - `io.containerd.runc.v2` (Default): `runc` runtime that supports multiple containers per shim.
 - `io.containerd.runsc.v1`: `gVisor` is an OCI compliant container runtime which provides better security than `runc`. They achieve this by implementing a user space kernel written in go, which implements a substantial portion of the Linux system call interface. For more details, please check their [`official documentation`](https://gvisor.dev/docs/)
+- `io.containerd.nvidia.v1`: `nvidia` is a container runtime that supports GPU devices.
 
 **Task Config**
 

--- a/example/gpu-nvidia-smi-sleep.nomad
+++ b/example/gpu-nvidia-smi-sleep.nomad
@@ -1,0 +1,30 @@
+job "gpu-nvidia-smi-sleep" {
+  datacenters = ["dc1"]
+
+  group "gpu-nvidia-smi-sleepgroup" {
+    task "gpu-nvidia-smi-sleep-task" {
+      driver = "containerd-driver"
+
+      # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
+      env {
+        NVIDIA_DRIVER_CAPABILITIES = "utility"
+      }
+
+      config {
+        image = "debian:stretch"
+        args = ["nvidia-smi",";", "sleep", "infinity"]
+      }
+
+      resources {
+        cpu    = 64
+        memory = 64
+
+        # https://www.nomadproject.io/docs/devices/external/nvidia
+        # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#containerd
+        device "nvidia/gpu" {
+          count = 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Checks device environment variables (just like docker task driver plugin) to setup GPU devices. Unlike docker plugin inspect task driver environment variables to setup GPU capabilities will default to 'utility' if none.